### PR TITLE
Display Boolean field values correctly and add tests

### DIFF
--- a/src/__snapshots__/panelTable.test.tsx.snap
+++ b/src/__snapshots__/panelTable.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PanelTable should render correctly 1`] = `
+exports[`PanelTable should render collapsed 1`] = `
 <DocumentFragment>
   <div
     style="opacity: 1; transition: all 0.3s ease-in 0s;"

--- a/src/devTool.test.tsx
+++ b/src/devTool.test.tsx
@@ -2,10 +2,6 @@ import * as React from 'react';
 import { DevTool } from './devTool';
 import { render } from '@testing-library/react';
 
-jest.mock('lodash/get', () => ({
-  default: () => {},
-}));
-
 describe('DevTool', () => {
   it('render correctly ', () => {
     // @ts-ignore

--- a/src/panelTable.test.tsx
+++ b/src/panelTable.test.tsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import PanelTable from './panelTable';
 
-jest.mock('lodash/isUndefined', () => ({ default: () => {} }));
-jest.mock('lodash/isObject', () => ({ default: () => {} }));
-
 describe('PanelTable', () => {
-  it('should render correctly', () => {
+  it('should render collapsed', () => {
     const { asFragment } = render(
       <PanelTable
         isNative={false}
@@ -25,5 +22,184 @@ describe('PanelTable', () => {
       />,
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should render string field values correctly', () => {
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: 'RHF' }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toBe('RHF');
+  });
+
+  it('should render number field values correctly', () => {
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: 1234 }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toBe('1234');
+  });
+
+  it('should render boolean field values correctly', () => {
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: false }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toBe('false');
+  });
+
+  it('should render null field values correctly', () => {
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: null }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toBe('null');
+  });
+
+  it('should render object field values correctly', () => {
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: { deeply: { nested: 'value' } } }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toMatchInlineSnapshot(`
+      "{
+        \\"deeply\\": {
+          \\"nested\\": \\"value\\"
+        }
+      }"
+    `);
+  });
+
+  it('should render non-serializable field values correctly', () => {
+    const circular: any = {};
+    circular.circular = circular;
+
+    const { getByTitle, getByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: circular }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(getByTestId('test-field-value').textContent).toMatchInlineSnapshot(
+      `"[Nested Object]"`,
+    );
+  });
+
+  it('should not render undefined field values', () => {
+    const { getByTitle, queryByTestId } = render(
+      <PanelTable
+        isNative={false}
+        errorMessage="test"
+        errorType="test"
+        hasError
+        type="test"
+        isTouched
+        isDirty
+        readFormStateRef={{ current: { touched: false } }}
+        index={0}
+        fieldsValues={{ test: undefined }}
+        name="test"
+        collapseAll={false}
+        refObject={{}}
+      />,
+    );
+
+    fireEvent.click(getByTitle('Toggle field table'));
+
+    expect(queryByTestId('test-field-value')).toBeNull();
   });
 });

--- a/src/panelTable.tsx
+++ b/src/panelTable.tsx
@@ -46,17 +46,21 @@ const PanelTable = ({
 
   let value = fieldsValues ? fieldsValues[name] : '';
 
-  if (fieldsValues && isObject(fieldsValues[name])) {
-    try {
-      value = (
-        <pre style={{ margin: 0 }}>
-          <code style={{ fontSize: 12 }}>
-            {JSON.stringify(fieldsValues[name], null, 2)}
-          </code>
-        </pre>
-      );
-    } catch {
-      value = <span>[Nested Object]</span>;
+  if (fieldsValues) {
+    if (isObject(fieldsValues[name])) {
+      try {
+        value = (
+          <pre style={{ margin: 0 }}>
+            <code style={{ fontSize: 12 }}>
+              {JSON.stringify(fieldsValues[name], null, 2)}
+            </code>
+          </pre>
+        );
+      } catch {
+        value = <span>[Nested Object]</span>;
+      }
+    } else if (typeof fieldsValues[name] !== 'string') {
+      value = String(fieldsValues[name]);
     }
   }
 
@@ -228,6 +232,7 @@ const PanelTable = ({
                   Value:
                 </td>
                 <td
+                  data-testid={`${name}-field-value`}
                   style={{
                     display: 'block',
                     maxWidth: 100,

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
I noticed that fields with Boolean values didn't appear in RHF DevTools. Root cause was that the `true`/`false` value was being rendered as a JSX child, which renders nothing.

I fixed that issue by adding a check to ensure that non-object, non-string values are always converted to strings before being rendered.

I also added some test cases for different types of field values. While I was working on this, I noticed that the `tsconfig.jest.json` didn't have `esModuleInterop` enabled, which was breaking `lodash` imports in files under test, so I fixed that as well.