### PR TITLE
Fix devtools.js module export

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@ if (process.env.NODE_ENV === 'production') {
     DevTool: () => null,
   }
 } else {
-  module.exports = require('./dist/react-hook-form-devtools.js')
+  module.exports = require('./dist/devtools.js')
 }


### PR DESCRIPTION
Before this change index.js was referencing a devtools at a filepath that no longer exists since migrating to `@hookform/devtools`.

After this change, `index.js` correctly exports the renamed `devtools.js` file.